### PR TITLE
Fix footer links

### DIFF
--- a/src/_includes/partials/footer.html
+++ b/src/_includes/partials/footer.html
@@ -11,13 +11,13 @@
 		</div>
 		<div>
 			<div class="font-display text-white uppercase text-sm tracking-widest mb-6">{{ footer.section_two_title }}</div>
-			{% for item in footer.section_one_links %}
+			{% for item in footer.section_two_links %}
 				<a href="{{ item.url }}" class="block mb-4">{{ item.text }}</a>
 			{% endfor %}
 		</div>
 		<div>
 			<div class="font-display text-white uppercase text-sm tracking-widest mb-6">{{ footer.section_three_title }}</div>
-			{% for item in footer.section_one_links %}
+			{% for item in footer.section_three_links %}
 				<a href="{{ item.url }}" class="block mb-4">{{ item.text }}</a>
 			{% endfor %}
 		</div>


### PR DESCRIPTION
The section one links are used for all three sections. This corrects it.